### PR TITLE
Marksheet XML & XSL

### DIFF
--- a/Lab8/marksheet.xml
+++ b/Lab8/marksheet.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marksheet>
+    <student>
+        <name>Khushi</name>
+        <roll_number>186147</roll_number>
+        <semester>3</semester>
+        <subjects>
+            <subject>
+                <name>Java</name>
+                <marks>88</marks>
+                <max_marks>100</max_marks>
+            </subject>
+            <subject>
+                <name>DSA</name>
+                <marks>92</marks>
+                <max_marks>100</max_marks>
+            </subject>
+            <subject>
+                <name>Mathematics</name>
+                <marks>85</marks>
+                <max_marks>100</max_marks>
+            </subject>
+            <subject>
+                <name>DBMS</name>
+                <marks>89</marks>
+                <max_marks>100</max_marks>
+            </subject>
+            <subject>
+                <name>Python</name>
+                <marks>94</marks>
+                <max_marks>100</max_marks>
+            </subject>
+            <subject>
+                <name>Dotnet</name>
+                <marks>90</marks>
+                <max_marks>100</max_marks>
+            </subject>
+        </subjects>
+    </student>
+</marksheet>

--- a/Lab8/marksheet.xsl
+++ b/Lab8/marksheet.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" indent="yes"/>
+    <xsl:template match="/">
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+                <title>Semester Mark Sheet</title>
+                <style>
+                    table {
+                        width: 60%;
+                        border-collapse: collapse;
+                    }
+                    th, td {
+                        border: 1px solid black;
+                        padding: 8px;
+                        text-align: center;
+                    }
+                    th {
+                        background-color: #f2f2f2;
+                    }
+                </style>
+            </head>
+            <body>
+                <h1>Semester Mark Sheet</h1>
+                <table>
+                    <tr>
+                        <th>Subject</th>
+                        <th>Marks Obtained</th>
+                        <th>Max Marks</th>
+                    </tr>
+                    <xsl:for-each select="marksheet/student/subjects/subject">
+                        <tr>
+                            <td><xsl:value-of select="name"/></td>
+                            <td><xsl:value-of select="marks"/></td>
+                            <td><xsl:value-of select="max_marks"/></td>
+                        </tr>
+                    </xsl:for-each>
+                </table>
+                <p><strong>Student Name:</strong> <xsl:value-of select="marksheet/student/name"/></p>
+                <p><strong>Roll Number:</strong> <xsl:value-of select="marksheet/student/roll_number"/></p>
+                <p><strong>Semester:</strong> <xsl:value-of select="marksheet/student/semester"/></p>
+            </body>
+        </html>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Merge feature/marksheet-xml-xsl into main

Detailed Changes:
- Added an XML file for storing semester mark sheet details.
- Subjects included are Java, DSA, Maths, DBMS, Python, Dotnet.
- Created an XSLT file to transform the XML data into an XHTML table format.
- The XHTML output includes the student's name, roll number, semester, and subject-wise marks in a table.
